### PR TITLE
Allow detect_rescan to use local Detect Jar instead of Detect sh script

### DIFF
--- a/detect_rescan.sh
+++ b/detect_rescan.sh
@@ -31,9 +31,6 @@
 output() {
     echo "detect_rescan: $*"
 }
-
-set -x
-set -v
  
 output "Starting Detect Rescan wrapper v1.16b"
 


### PR DESCRIPTION
NOTE - This was reviewed in pull request 1 but not merged.  Creating new pull request to merge. See https://github.com/blackducksoftware/detect_rescan/pull/1

Some customers scanning wrappers used in their pipelines are complicated and already have the Detect jar locally (not the sh script). While they could download the Detect sh file along with the jar and store locally they would rather keep things simple and continue calling the Jar directly.

I have modified the script so you can pass in the location of --detectjar=. The detect_rescan script will then call java -jar instead of the Detect shell script.

Note I had tried this by passing in --detectscript="java -jar " but this requires quotes around the parameter that prevented it being executed correctly.